### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,36 @@
 language: python
 python:
-- "2.7"
-install: 'pip install -r requirements.txt'
-script: 'python ./manage.py test'
+  - "3.4"
+  - "3.3"
+  - "3.2"
+  - "2.7"
+  - "2.6"
+  - "pypy"
+  - "pypy3"
+env:
+  - DJANGO_VERSION=1.4.21
+  - DJANGO_VERSION=1.5.12
+  - DJANGO_VERSION=1.6.11
+  - DJANGO_VERSION=1.7.9
+  - DJANGO_VERSION=1.8.3
+install:
+  - pip install -q django==$DJANGO_VERSION
+  - pip install -r requirements.txt
+  - pip install coveralls
+script:
+  - env PYTHONPATH=`pwd` coverage run --source=crumbs ./manage.py test crumbs
+after_success:
+  coveralls
+matrix:
+  exclude:
+    - python: "pypy3"
+      env: DJANGO_VERSION=1.4.21
+    - python: "3.4"
+      env: DJANGO_VERSION=1.4.21
+    - python: "3.3"
+      env: DJANGO_VERSION=1.4.21
+    - python: "3.2"
+      env: DJANGO_VERSION=1.4.21
+    - python: "2.6"
+      env: DJANGO_VERSION=1.7.9
+    - python: "2.6"

--- a/README.rst
+++ b/README.rst
@@ -5,13 +5,7 @@ Django Crumbs Mixin
 Put short description here...
 
 .. image:: https://travis-ci.org/bashu/django-crumbs-mixin.svg?branch=develop
-   :target: https://travis-ci.org/bashu/django-crumbs-mixin
-   :alt: Build Status
+    :target: https://travis-ci.org/bashu/django-crumbs-mixin
 
-.. image:: https://badge.fury.io/py/django-crumbs-mixin.png
-   :target: http://badge.fury.io/py/django-crumbs-mixin
-   :alt: Latest Release
-
-.. image:: https://pypip.in/d/django-crumbs-mixin/badge.png
-   :target: https://crate.io/packages/django-crumbs-mixin?version=latest
-   :alt: Downloads
+.. image:: https://landscape.io/github/bashu/django-crumbs-mixin/develop/landscape.svg?style=flat
+    :target: https://landscape.io/github/bashu/django-crumbs-mixin/develop


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20django-crumbs-mixin))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `django-crumbs-mixin`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.